### PR TITLE
Fix MDP compile

### DIFF
--- a/rl2023/exercise1/mdp.py
+++ b/rl2023/exercise1/mdp.py
@@ -1,6 +1,7 @@
 import numpy as np
 from collections import namedtuple
 from typing import List, Hashable
+from ordered_set import OrderedSet
 
 Transition = namedtuple(
     "Transition", ["state", "action", "next_state", "prob", "reward"]
@@ -17,9 +18,9 @@ class MDP:
     Allows for easy creation and generation of numpy arrays for faster computation
 
     :attr transitions (List[Transition]): list of all transitions
-    :attr states (Set[State]): set of all states
-    :attr actions (Set[Action]): set of all actions
-    :attr terminal_states (Set[State]): set of all terminal states (NOT USED)
+    :attr states (OrderedSet[State]): set of all states
+    :attr actions (OrderedSet[Action]): set of all actions
+    :attr terminal_states (OrderedSet[State]): set of all terminal states (NOT USED)
     :attr init_state (State): initial state (NOT USED)
     :attr max_episode_length (int): maximum length of an episode (NOT USED)
     :attr _state_dict (Dict[State, int]): mapping from states to state indeces
@@ -48,9 +49,9 @@ class MDP:
         Initialise an empty (!) MDP
         """
         self.transitions = []
-        self.states = set()
-        self.actions = set()
-        self.terminal_states = set()
+        self.states = OrderedSet()
+        self.actions = OrderedSet()
+        self.terminal_states = OrderedSet()
 
         self.init_state = None
         self.max_episode_length = None
@@ -134,9 +135,9 @@ class MDP:
     def _decompile(self):
         """Resets states and actions to modifiable sets and toggles the compiled flag off
         """
-        self.states = set(self.states)
-        self.actions = set(self.actions)
-        self.terminal_states = set(self.terminal_states)
+        self.states = OrderedSet(self.states)
+        self.actions = OrderedSet(self.actions)
+        self.terminal_states = OrderedSet(self.terminal_states)
         self._state_dict = {}
         self._action_dict = {}
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "pyglet>=1.3",
         "matplotlib>=3.1",
         "pytest>=5.3",
+        "ordered_set>=4.1",
     ],
     extras_require={"test": ["pytest"]},
     include_package_data=True,


### PR DESCRIPTION
In exercise 1, it seems `MDP` class is not compiled deterministically. Here is an example:
```python
mdp = MDP()

mdp.add_transition(
        Transition('state0', 'action0', 'state0', 1.0, 0.0),
        Transition('state1', 'action0', 'state0', 1.0, 0.0),
)

mdp.ensure_compiled()
print(mdp.P[0, 0, 0])    # Should always be 1, since p(s0 -a0-> s0) = 1
```

But `print(mdp.P[0, 0, 0])` sometimes prints `0`, sometimes prints `1`

To keep minimal changes, the default `set` can be overwritten with a custom `OrderedSet`